### PR TITLE
Install iputils-ping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN \
       tzdata \
       curl \
       jq \
+      iputils-ping \
       ruby-sass
 ENV IS_DOCKER=true
 ENV STATPING_DIR=/app


### PR DESCRIPTION
ICMP Polling currently not working as ping is not installed in the image. Error below:

```
WARN[152693] Service redacted Failing: Could not send ICMP to service redacted, exec: "ping": executable file not found in $PATH
```